### PR TITLE
nix: improve flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
   build:
@@ -32,3 +31,7 @@ jobs:
 
       - name: Build
         run: nix build ".#nyoom"
+
+      - name: Build (static)
+        if: matrix.runner == 'ubuntu-latest'
+        run: nix build '.#nyoom-static'

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # Nix
-result
+result*
 .direnv/
 
 # Rust

--- a/flake.lock
+++ b/flake.lock
@@ -1,8 +1,67 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688772518,
+        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -20,45 +79,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689534811,
-        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
+        "lastModified": 1689503327,
+        "narHash": "sha256-qVwzYLA8oT2oWNDXO0A3bZHOhoPOihIB9T677+Hor1E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
+        "rev": "f64b9738da8e86195766147e9752c67fccee006c",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.05",
         "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1689561325,
@@ -75,6 +121,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,27 +2,43 @@
   description = "A small CLI Firefox userchrome manager";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    nixpkgs.url = "nixpkgs/nixos-23.05";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
   };
 
   outputs =
     { self
     , nixpkgs
+    , crane
     , rust-overlay
     , ...
     }:
     let
       version = builtins.substring 0 8 self.lastModifiedDate;
 
-      systems = [
+      linux = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
       ];
 
-      forAllSystems = nixpkgs.lib.genAttrs systems;
+      systems =
+        [
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ]
+        ++ linux;
+
+      inherit (nixpkgs) lib;
+
+      forAllSystems = lib.genAttrs systems;
       nixpkgsFor = forAllSystems (system:
         import nixpkgs {
           inherit system;
@@ -35,16 +51,30 @@
             inherit system;
             pkgs = nixpkgsFor.${system};
           });
+
+      toolchainFor = forEachSystem (
+        { pkgs
+        , system
+        , ...
+        }:
+        pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" ];
+          targets = lib.optionals (builtins.elem system linux) [
+            "x86_64-unknown-linux-musl"
+            "aarch64-unknown-linux-musl"
+          ];
+        }
+      );
     in
     {
-      devShells = forEachSystem ({ pkgs, ... }:
-        let
-          inherit (pkgs) mkShell;
-        in
-        {
-          default = mkShell {
+      devShells = forEachSystem
+        ({ pkgs
+         , system
+         , ...
+         }: {
+          default = pkgs.mkShell {
             packages = with pkgs; [
-              rust-bin.stable.latest.default
+              toolchainFor.${system}
               rust-analyzer
             ];
 
@@ -52,29 +82,63 @@
           };
         });
 
-      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixpkgs-fmt);
+      formatter = forEachSystem (p: p.pkgs.nixpkgs-fmt);
 
-      packages = forEachSystem ({ pkgs, ... }: {
-        inherit (pkgs) nyoom;
-        default = pkgs.nyoom;
-      });
+      packages = forEachSystem
+        ({ pkgs
+         , system
+         , ...
+         }:
+          lib.recursiveUpdate
+            {
+              inherit (pkgs) nyoom;
+              default = pkgs.nyoom;
+            }
+            (
+              lib.optionalAttrs (builtins.elem system linux) {
+                nyoom-static =
+                  let
+                    arch =
+                      if system == "x86_64-linux"
+                      then "x86_64"
+                      else if system == "aarch64-linux"
+                      then "aarch64"
+                      else "";
 
-      overlays.default = _: prev: {
-        nyoom = prev.pkgs.rustPlatform.buildRustPackage
-          {
-            pname = "nyoom";
-            inherit version;
+                    flags.CARGO_BUILD_TARGET = "${arch}-unknown-linux-musl";
+                    flags."CARGO_TARGET_${lib.toUpper arch}_UNKNOWN_LINUX_MUSL_LINKER" =
+                      let
+                        inherit (pkgs.pkgsStatic.stdenv) cc;
+                      in
+                      "${cc}/bin/${cc.targetPrefix}cc";
+                  in
+                  pkgs.nyoom.overrideAttrs (_:
+                    {
+                      # optimize for size
+                      CARGO_BUILD_RUSTFLAGS = "-C strip=symbols -C target-feature=+crt-static -C opt-level=z -C codegen-units=1";
+                    }
+                    // flags);
+              }
+            ));
 
-            src = self;
-
-            cargoLock.lockFile = "${self}/Cargo.lock";
-
-            buildInputs = with prev.pkgs; [ ];
-
-            nativeBuildInputs = with prev.pkgs; [
-              pkg-config
-            ];
-          };
-      };
+      overlays.default = _: prev:
+        let
+          crane' = crane.mkLib prev;
+        in
+        {
+          nyoom =
+            let
+              isLinux = builtins.elem prev.system linux;
+              buildRustPackage =
+                if isLinux
+                then (crane'.overrideToolchain toolchainFor.${prev.system}).buildPackage
+                else crane'.buildPackage;
+            in
+            buildRustPackage {
+              pname = "nyoom";
+              inherit version;
+              src = self;
+            };
+        };
     };
 }


### PR DESCRIPTION
this adds static builds for nix, some stuff to make the binary smaller (especially for static builds), and adds checks with clippy + rustfmt to `nix flake check`

i also how to downgrade nixpkgs to 23.05...not sure why but static builds don't work *only* in your flake /shurg
