### PR TITLE
Revert "nix: filter package source to sources only"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,15 +83,15 @@
 
       overlays.default = _: prev: {
         nyoom = prev.callPackage
-          ({ darwin, lib, lto ? true, optimizeSize ? true, pkg-config, rustPlatform, stdenv, version, self }:
+          ({ darwin, lib, lto ? true, optimizeSize ? true, pkg-config, rustPlatform, self, stdenv, version }:
             rustPlatform.buildRustPackage
               {
                 pname = "nyoom";
                 inherit version;
 
-                src = lib.sourceByRegex self [ "^src" "^presets" ".*\.rs$" ".*\.toml$" "^Cargo\.toml$" "^Cargo\.lock$" ];
-                cargoLock.lockFile = ./Cargo.lock;
+                src = self;
 
+                cargoLock.lockFile = "${self}/Cargo.lock";
                 RUSTFLAGS = ""
                   + lib.optionalString lto " -C lto=thin -C embed-bitcode=yes"
                   + lib.optionalString optimizeSize " -C codegen-units=1 -C strip=symbols -C opt-level=z";


### PR DESCRIPTION
this doesn't do anything as `self` is already a store path and not present in the final closure anyways; this should only be used for subprojects. relative paths also shouldn't be used here, see [this](https://nix.dev/recipes/best-practices#reproducible-source-paths) section on nix.dev (`self` == `builtins.path`) 
